### PR TITLE
Adds additional information to the manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ license = "MIT"
 keywords = ["parser", "parser-combinators", "parsing", "streaming", "async"]
 categories = ["parsing"]
 repository = "https://github.com/rust-bakery/nom-bufreader"
+readme = "README.md"
+documentation = "https://docs.rs/nom-bufreader"
 
 [dependencies]
 nom = "7.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "BufReader adapter for nom parsers"
 license = "MIT"
 keywords = ["parser", "parser-combinators", "parsing", "streaming", "async"]
 categories = ["parsing"]
+repository = "https://github.com/rust-bakery/nom-bufreader"
 
 [dependencies]
 nom = "7.0.0"


### PR DESCRIPTION
Self-explanatory, but it just took me a moment to figure out where the repository was when I was looking at [the crate description](https://crates.io/crates/nom-bufreader/0.2.0).