### PR TITLE
Reduce dependencies on futures crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ categories = ["parsing"]
 [dependencies]
 nom = "7.0.0"
 async-trait = { version = "0.1.51", optional = true }
-futures = { version = "0.3.16", optional = true }
+futures-io = { version = "0.3.16", default-features = false, optional = true }
+futures-util = { version = "0.3.16", default-features = false, features = ["io"], optional = true }
 pin-project-lite = { version = "0.2.7", optional = true }
 
 [dev-dependencies]
@@ -21,4 +22,4 @@ tokio-util = { version = "0.6.7", features = ["compat"] }
 
 [features]
 default = ["async"]
-async = ["futures", "async-trait", "pin-project-lite"]
+async = ["futures-io", "futures-util", "async-trait", "pin-project-lite"]

--- a/src/async_bufreader.rs
+++ b/src/async_bufreader.rs
@@ -1,10 +1,10 @@
 use super::bufreader::DEFAULT_BUF_SIZE;
-use futures::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, IoSliceMut, SeekFrom};
-use futures::ready;
-use futures::task::{Context, Poll};
+use futures_io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, IoSliceMut, SeekFrom};
+use futures_util::ready;
 use pin_project_lite::pin_project;
 use std::io::{self, Read};
 use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::{cmp, fmt};
 
 pin_project! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,10 +78,9 @@ use std::io::{self, BufRead, Read};
 #[cfg(feature = "async")]
 use async_trait::async_trait;
 #[cfg(feature = "async")]
-use futures::{
-    io::{AsyncBufReadExt, BufReader},
-    AsyncRead,
-};
+use futures_io::AsyncRead;
+#[cfg(feature = "async")]
+use futures_util::io::{AsyncBufReadExt, BufReader};
 
 #[cfg(feature = "async")]
 pub mod async_bufreader;


### PR DESCRIPTION
This removes `futures-channel`, `futures-executor` & `futures-sink` as transient dependencies.